### PR TITLE
Nit - corrected misspelling in error messages

### DIFF
--- a/dist/arithmetics.js
+++ b/dist/arithmetics.js
@@ -80,7 +80,7 @@ exports.mul = mul;
 var div = function (wizData, wizData2) {
     if (wizData.number !== undefined && wizData2.number !== undefined) {
         if (wizData2.number === 0)
-            throw "Error: dividing can't be eqaul 0.";
+            throw "Error: dividing can't be equal 0.";
         var divValue = wizData.number / wizData2.number;
         divValue = divValue > 0 ? Math.floor(divValue) : Math.ceil(divValue);
         return wiz_data_1.default.fromNumber(divValue);

--- a/dist/crypto.js
+++ b/dist/crypto.js
@@ -106,9 +106,9 @@ var tweakVerify = function (wizData, wizData2, wizData3) {
     var vchTweak = wizData2;
     var vchTweakedKey = wizData;
     if (vchTweak.bytes.length != 32)
-        throw "Tweak key length must be eqaul 32 byte";
+        throw "Tweak key length must be equal 32 byte";
     if (internalKey.bytes.length != 32)
-        throw "Internal key length must be eqaul 32 byte";
+        throw "Internal key length must be equal 32 byte";
     if (vchTweakedKey.bytes[0] !== 2 && vchTweakedKey.bytes[0] !== 3)
         throw "Tweaked key must start with 0x02 or 0x03";
     var isChecked = (0, taproot_1.publicKeyTweakCheckWithPrefix)(internalKey, vchTweak, vchTweakedKey);

--- a/src/arithmetics.ts
+++ b/src/arithmetics.ts
@@ -85,7 +85,7 @@ export const mul = (wizData: WizData, wizData2: WizData): WizData => {
 
 export const div = (wizData: WizData, wizData2: WizData): WizData => {
   if (wizData.number !== undefined && wizData2.number !== undefined) {
-    if (wizData2.number === 0) throw "Error: dividing can't be eqaul 0.";
+    if (wizData2.number === 0) throw "Error: dividing can't be equal 0.";
 
     let divValue: number = wizData.number / wizData2.number;
 

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -119,9 +119,9 @@ export const tweakVerify = (wizData: WizData, wizData2: WizData, wizData3: WizDa
   const vchTweak = wizData2;
   const vchTweakedKey = wizData;
 
-  if (vchTweak.bytes.length != 32) throw "Tweak key length must be eqaul 32 byte";
+  if (vchTweak.bytes.length != 32) throw "Tweak key length must be equal 32 byte";
 
-  if (internalKey.bytes.length != 32) throw "Internal key length must be eqaul 32 byte";
+  if (internalKey.bytes.length != 32) throw "Internal key length must be equal 32 byte";
 
   if (vchTweakedKey.bytes[0] !== 2 && vchTweakedKey.bytes[0] !== 3) throw "Tweaked key must start with 0x02 or 0x03";
 


### PR DESCRIPTION
"eqaul" is incorrect and should be "equal", just like OP_EQUAL. This is a very minor change but could be helpful to avoid confusion.